### PR TITLE
fix: useNativeDriver: false to FAB.tsx

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -147,13 +147,13 @@ const FAB = ({
       Animated.timing(visibility, {
         toValue: 1,
         duration: 200 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     } else {
       Animated.timing(visibility, {
         toValue: 0,
         duration: 150 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     }
   }, [visible, scale, visibility]);


### PR DESCRIPTION
Add useNativeDriver: false to FAB.tsx silencing the warning:
Animated: 'useNativeDriver' is not supported because the native animated module is missing. Falling back to JS-based animation. [...] at FAB